### PR TITLE
Docs: install `overarch` from Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,17 @@ To get support for icons (PlantUML sprites) from the PlantUML standard library, 
 
 ![PlantUML Extension Settings](/doc/images/vscode_plantuml_ext_settings.png)
 
+### Homebrew on macOS
+
+This project has been packaged in Homebrew for macOS users. Install it using
+```
+brew install overarch
+```
+
+This package includes an `overarch` convenience wrapper which handles tracking
+the location of the `overarch.jar` uberjar for you. This `overarch` command can
+be substituted for the `java -jar overarch.jar` references throughout this
+documentation.
 
 Usage
 -----


### PR DESCRIPTION
💁 Thank you for creating this project! I have found it useful in the past and have [recently packaged it in Homebrew](https://github.com/Homebrew/homebrew-core/pull/167886) to make the installation process easier for macOS users. This change adds documentation on how to install and use `overarch` for Homebrew.