### PR TITLE
Docs: Fix broken SVG file references

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,10 +251,10 @@ SHOW_LEGEND()
 ```
 
 ### System Context View rendered with PlantUML
-![System Context View rendered with PlantUML](/doc/images/banking_systemContextView.svg)
+![System Context View rendered with PlantUML](/doc/images/banking/system-context-view.svg)
 
 ### Container View rendered with PlantUML
-![Container View rendered with PlantUML](/doc/images/banking_containerView.svg)
+![Container View rendered with PlantUML](/doc/images/banking/container-view.svg)
 
 
 Build


### PR DESCRIPTION
💁 The changes in 433b987695bc443606c74b8572c284c2aeeb22a1 which changed the hierarchy for images appear to have broken a few inline images in the project `README`. These changes fix those references.