### PR TITLE
Feature/container-handling

### DIFF
--- a/models/banking/model.edn
+++ b/models/banking/model.edn
@@ -175,6 +175,12 @@
                  :id :banking/database
                  :name "Database"
                  :desc "Stores the user registration information, hashed authentication credentials, access logs, etc."
+                 :tech "Datomic"}
+                {:el :container
+                 :subtype :database
+                 :id :banking/database-read
+                 :name "Database for Reads"
+                 :desc "Stores the user registration information, hashed authentication credentials, access logs, etc."
                  :tech "Datomic"}}}
          ; external systems
          {:el :system
@@ -437,12 +443,6 @@
           :name "Secondary DB Server"
           :tech "Datomic"
           :desc "for reads"}}}
-  {:el :container
-   :subtype :database
-   :id :banking/database-read
-   :name "Database for Reads"
-   :desc "Stores the user registration information, hashed authentication credentials, access logs, etc."
-   :tech "Datomic"}
 
   ;;
   ;; Deployment Model Relations

--- a/models/banking/views.edn
+++ b/models/banking/views.edn
@@ -40,6 +40,7 @@
   {:el :container-view
    :id :banking/banking-container-view-with-selection
    :spec {:selection {:namespace :banking}
+          :include :related
           :plantuml {:sprite-libs [:azure :devicons :font-awesome-5]}}
    :title "Container View of the Internet Banking System"
    :ct [; selected elements will be included automatically
@@ -124,6 +125,7 @@
 
   {:el :deployment-view
    :id :banking/deployment-view
+   ;:spec {:include :related}
    :title "Deployment View of Big Bank plc"
    :ct [; model elements
         {:ref :banking/personal-customers-mobile-device}

--- a/src/org/soulspace/overarch/adapter/exports/structurizr.clj
+++ b/src/org/soulspace/overarch/adapter/exports/structurizr.clj
@@ -79,13 +79,12 @@
 
 (defmethod render-element :model-element
   [model indent e]
-  (if (:ct e)
-    (let [children (map (partial model/resolve-element model) (:ct e))]
-      [(str (export/indent indent) (alias-name (:id e)) " = "
-            (element-type->structurizr (:el e))
-            " \"" (el/element-name e) "\" {")
-       (map (partial render-element model (+ indent 2)) children)
-       (str (export/indent indent) "}")])
+  (if-let [children (mapv (model/element-resolver model) (model/children model e))]
+    [(str (export/indent indent) (alias-name (:id e)) " = "
+          (element-type->structurizr (:el e))
+          " \"" (el/element-name e) "\" {")
+     (map (partial render-element model (+ indent 2)) children)
+     (str (export/indent indent) "}")]
     [(str (export/indent indent) (alias-name (:id e)) " = "
           (element-type->structurizr (:el e))
           " \"" (el/element-name e) "\"")]))
@@ -107,7 +106,7 @@
                  " \"" (sstr/first-upper-case
                         (sstr/hyphen-to-camel-case
                          (view-type->structurizr (:el view)))) "\" {\n")
-            (if (:ct view)
+            (if (seq (model/children model view))
               (let [children (filter el/model-relation?
                                      (view/elements-to-render model view))]
                 (map (partial render-element model 6) children))

--- a/src/org/soulspace/overarch/adapter/render/plantuml.clj
+++ b/src/org/soulspace/overarch/adapter/render/plantuml.clj
@@ -193,12 +193,17 @@
 (defn collect-sprites
   "Returns the set of sprites for the elements of the `coll`."
   [coll]
-  (el/traverse :sprite sprite-collector coll))
+  (model/traverse :sprite sprite-collector coll))
+
+(defn collect-technologies
+  "Returns the set of technologies for the elements of the coll."
+  [coll]
+  (model/traverse :tech el/tech-collector coll))
 
 (defn collect-all-sprites
   "Collects all sprites for the collection of elements."
   [coll]
-  (filter sprite? (set/union (el/collect-technologies coll) (collect-sprites coll))))
+  (filter sprite? (set/union (collect-technologies coll) (collect-sprites coll))))
 
 (defn sprites-for-view
   "Collects the sprites for the `view`."

--- a/src/org/soulspace/overarch/adapter/render/plantuml/c4.clj
+++ b/src/org/soulspace/overarch/adapter/render/plantuml/c4.clj
@@ -158,16 +158,11 @@
 
 (defmethod render-c4-element :node
   [model view indent e]
-  (let [deployed (->> model
-                      (:referred-id->relations)
-                      ((:id e))
-                      (filter (partial el/el? :deployed-to))
-                      (map :from)
-                      (map (partial model/resolve-id model)))
+  (let [deployed (model/deployed-on model e)
         children (model/children model e)
         content (concat (view/elements-to-render model view children)
                          (view/elements-to-render model view deployed))]
-    (if (seq children)
+    (if (seq content)
       (flatten [(str (render/indent indent)
                      (c4-element->method (:el e)) "("
                      (puml/alias-name (:id e)) ", \""

--- a/src/org/soulspace/overarch/adapter/render/plantuml/c4.clj
+++ b/src/org/soulspace/overarch/adapter/render/plantuml/c4.clj
@@ -89,8 +89,8 @@
 
 (defmethod render-c4-element :boundary
   [model view indent e]
-  (if (seq (:ct e))
-    (let [children (view/elements-to-render model view (:ct e))]
+  (if-let [children (seq (model/children model e))]
+    (let [content (view/elements-to-render model view children)]
       (flatten [(str (render/indent indent)
                      (c4-element->method (:el e)) "("
                      (puml/alias-name (:id e)) ", \""
@@ -98,7 +98,7 @@
                      (when (:style e) (str ", $tags=\"" (puml/short-name (:style e)) "\""))
                      ") {")
                 (map #(render-c4-element model view (+ indent 2) %)
-                     children)
+                     content)
                 (str (render/indent indent) "}")]))
     [(str (render/indent indent)
           (c4-element->method (:el e)) "("
@@ -164,7 +164,8 @@
                       (filter (partial el/el? :deployed-to))
                       (map :from)
                       (map (partial model/resolve-id model)))
-        children (concat (view/elements-to-render model view (:ct e))
+        children (model/children model e)
+        content (concat (view/elements-to-render model view children)
                          (view/elements-to-render model view deployed))]
     (if (seq children)
       (flatten [(str (render/indent indent)
@@ -181,7 +182,7 @@
                      (when (:style e) (str ", $tag=\"" (puml/short-name (:style e)) "\""))
                      ") {")
                 (map #(render-c4-element model view (+ indent 2) %)
-                     children)
+                     content)
                 (str (render/indent indent) "}")])
       [(str (render/indent indent)
             (c4-element->method (:el e)) "("

--- a/src/org/soulspace/overarch/adapter/template/model_api.clj
+++ b/src/org/soulspace/overarch/adapter/template/model_api.clj
@@ -12,6 +12,10 @@
 ;;;;
 
 ;;;
+;;; TODO close over model!?
+;;;
+
+;;;
 ;;; Element Predicates
 ;;;
 (defn model-element?
@@ -121,9 +125,9 @@
   (model/parent model e))
 
 (defn children
-  "Returns the parent of the node `e` in the `model`."
+  "Returns the children of the node `e` in the `model`."
   [model e]
-  (el/children e))
+  (model/children model e))
 
 (defn ancestor-nodes
   "Returns the set of ancestor nodes of the model node `e` in the `model`."
@@ -235,12 +239,12 @@
 (defn all-fields
   "Returns a sequence of all fields of the given collection of `classes`."
   [model classes]
-  (el/collect-fields classes))
+  (model/collect-fields model classes))
 
 (defn all-methods
   "Returns a sequence of all methods of the given collection of `classes`."
   [model classes]
-  (el/collect-methods classes))
+  (model/collect-methods model classes))
 
 (defn superclasses
   "Returns the set of direct superclasses of the class element `e` in the `model`."

--- a/src/org/soulspace/overarch/adapter/ui/cli.clj
+++ b/src/org/soulspace/overarch/adapter/ui/cli.clj
@@ -270,6 +270,9 @@
   (model-info (repo/update-state! {:model-dir "models/banking:models/overarch"})
               {:model-info true})
   (repo/update-state! {:model-dir "models/banking"})
+  (repo/update-state! {:model-dir "models/overarch"})
+  
+  ;
   )
 
 (comment ; model analytics 

--- a/src/org/soulspace/overarch/adapter/ui/cli.clj
+++ b/src/org/soulspace/overarch/adapter/ui/cli.clj
@@ -7,6 +7,7 @@
             [nextjournal.beholder :as beholder]
             [org.soulspace.overarch.domain.element :as el]
             [org.soulspace.overarch.domain.model :as model]
+            [org.soulspace.overarch.domain.view :as view]
             [org.soulspace.overarch.domain.analytics :as al]
             [org.soulspace.overarch.application.model-repository :as repo]
             [org.soulspace.overarch.application.export :as exp]
@@ -256,16 +257,19 @@
       ; handle options and generate the requested outputs
       (handle options))))
 
-(comment ; state
+;;;
+;;; Rich comments for tests and explorations
+;;;
+(comment ; state update
   (update-and-dispatch! {:model-dir "models"
                          :export-dir "export"
                          :render-dir "export"
                          :render-format :plantuml
                          :debug true})
   
-  (model-info (repo/update-state! {:model-dir "models/banking:models/overarch"}) {:model-info true})
-  (repo/update-state! {:model-dir "models"})
-  (repo/update-state! {:model-dir "C:/pag/datona/git/datona-architecture-documentation/models"})  ;
+  (model-info (repo/update-state! {:model-dir "models/banking:models/overarch"})
+              {:model-info true})
+  (repo/update-state! {:model-dir "models/banking"})
   )
 
 (comment ; model analytics 
@@ -286,10 +290,10 @@
 
   (al/unidentifiable-elements (concat (repo/nodes) (repo/relations)))
   (al/unnamespaced-elements (concat (repo/nodes) (repo/relations)))
-  (al/unrelated-nodes @repo/state)
-  (al/check-relations @repo/state)
-  (al/check-views @repo/state)
-  (al/unresolved-refs  @repo/state (model/resolve-element @repo/state :test/missing-elements))
+  (al/unrelated-nodes (repo/model))
+  (al/check-relations (repo/model))
+  (al/check-views (repo/model))
+  (al/unresolved-refs  (repo/model) (model/resolve-element @repo/state :test/missing-elements))
   (al/unmatched-relation-namespaces (repo/relations))
 
   (el/elements-by-namespace (repo/nodes))
@@ -300,25 +304,85 @@
   )
 
 (comment ; model navigation 
-  (model/descendant-nodes (repo/model) (model/resolve-element (repo/model) :banking/internet-banking-system))
+  (model/descendant-nodes (repo/model)
+                          (model/resolve-element (repo/model)
+                                                 :banking/internet-banking-system))
   ;
   )
 
 (comment ; selections
-  (into #{} (model/filter-xf @repo/state {:namespace "ddd"}) (repo/nodes))
-  (into #{} (model/filter-xf @repo/state {:namespace "ddd"}) (repo/relations))
-  (into #{} (model/filter-xf @repo/state {:subtype :queue}) (repo/nodes))
+  (into #{} (model/filter-xf (repo/model) {:namespace "ddd"}) (repo/nodes))
+  (into #{} (model/filter-xf (repo/model) {:namespace "ddd"}) (repo/relations))
+  (into #{} (model/filter-xf (repo/model) {:subtype :queue}) (repo/nodes))
 
-  (into #{} (model/filter-xf @repo/state {:namespace "banking"}) (repo/nodes))
-  (into #{} (model/filter-xf @repo/state {:namespace "banking"}) (repo/relations))
+  (into #{} (model/filter-xf (repo/model) {:namespace "banking"}) (repo/nodes))
+  (into #{} (model/filter-xf (repo/model) {:namespace "banking"}) (repo/relations))
 
   (into #{}
-        (model/filter-xf @repo/state {:namespace "overarch.data-model"})
+        (model/filter-xf (repo/model) {:namespace "overarch.data-model"})
         (repo/model-elements))
   (->> (into #{}
-             (model/filter-xf @repo/state {:namespace "overarch.data-model"})
+             (model/filter-xf (repo/model) {:namespace "overarch.data-model"})
              (repo/model-elements))
-       (el/collect-fields))
+       (model/collect-fields (repo/model)))
+  ;
+  )
+
+(comment ; view functions
+  (def referenced
+    (view/referenced-elements (repo/model)
+                              (model/resolve-element (repo/model)
+                                                     :banking/container-view)))
+  (def selected
+    (view/selected-elements (repo/model)
+                            (model/resolve-element (repo/model)
+                                                   :banking/container-view)))
+  (view/specified-elements (repo/model)
+                           (model/resolve-element (repo/model)
+                                                  :banking/container-view))
+  (def specified
+    (view/specified-elements (repo/model)
+                             (model/resolve-element (repo/model)
+                                                    :banking/container-view)))
+  (def included
+    (view/included-elements (repo/model)
+                            (model/resolve-element (repo/model)
+                                                   :banking/container-view)
+                            specified))
+  included
+  (def in-view
+    (view/view-elements (repo/model)
+                        (model/resolve-element (repo/model)
+                                               :banking/container-view)))
+  (def rendered
+    (view/elements-to-render (repo/model)
+                             (model/resolve-element (repo/model)
+                                                    :banking/container-view)))
+
+  ;
+  )
+
+(comment ; render functions
+  (model/children (repo/model)
+                  (model/resolve-element (repo/model)
+                                         :banking/internet-banking-system))
+  (c4/render-c4-element (repo/model)
+                        (model/resolve-element (repo/model)
+                                               :banking/container-view)
+                        0
+                        (model/resolve-element (repo/model)
+                                               :banking/internet-banking-system))
+  
+  (model/deployed-on (repo/model)
+                     (model/resolve-element (repo/model)
+                                            :banking/big-bank-api-server-pod))
+  (c4/render-c4-element (repo/model)
+                        (model/resolve-element (repo/model)
+                                               :banking/container-view)
+                        0
+                        (model/resolve-element (repo/model)
+                                               :banking/big-bank-plc-datacenter))
+
   ;
   )
 

--- a/src/org/soulspace/overarch/domain/analytics.clj
+++ b/src/org/soulspace/overarch/domain/analytics.clj
@@ -147,11 +147,20 @@
 (defn unresolved-refs
   "Checks references in an element."
   [model element]
-  (->> (:ct element)
+  (->> (model/children model element)
        (filter el/reference?)
        (map (partial model/resolve-ref model))
        (filter el/unresolved-ref?)
        (map #(assoc % :parent (:id element)))))
+
+(defn unresolved-refs-in-view
+  "Checks references in a view."
+  [model view]
+  (->> (:ct view)
+       (filter el/reference?)
+       (map (partial model/resolve-ref model))
+       (filter el/unresolved-ref?)
+       (map #(assoc % :parent (:id view)))))
 
 (defn check-relations
   "Validates the relations in the model."
@@ -166,4 +175,4 @@
 (defn check-views
   "Validates the references in the views."
   [model]
-  (mapcat (partial unresolved-refs model) (model/views model)))
+  (mapcat (partial unresolved-refs-in-view model) (model/views model)))

--- a/src/org/soulspace/overarch/domain/element.clj
+++ b/src/org/soulspace/overarch/domain/element.clj
@@ -710,7 +710,7 @@
            p-name (name (:id p))]
        (keyword (str p-namespace "/"
                      p-name "-"
-                     (str/lower-case (:name e)) "-"
+                     (str/replace (str/lower-case (:name e)) " " "-") "-"
                      (name (:el e))))))))
 
 (defn generate-relation-id

--- a/src/org/soulspace/overarch/domain/element.clj
+++ b/src/org/soulspace/overarch/domain/element.clj
@@ -139,7 +139,8 @@
 
 (def model-relation-types
   "Relation types of the model."
-  (set/union #{:rel :contains}
+  ; TODO only one of contains/contained-in
+  (set/union #{:rel :contains :contained-in}
              architecture-relation-types
              deployment-relation-types
              uml-relation-types
@@ -424,7 +425,9 @@
       (derive :concept-model-relation            :model-relation)
       (derive :organization-model-relation       :model-relation)
 
+      ; TODO only one of contains/contained-in
       (derive :contains                          :model-relation)
+      (derive :contained-in                      :model-relation)
       (derive :rel                               :model-relation)
 
       ;;; model elements
@@ -596,16 +599,6 @@
   [e]
   (boolean (:unresolved-ref e)))
 
-(defn child?
-  "Returns true, if element `e` is a child of model element `p`."
-  [e p]
-  (boolean (and (seq e)
-                (seq p)
-                (identifiable-element? e)
-                (identifiable-element? p)
-                (model-element? p)
-                (contains? (set (:ct p)) e))))
-
 (defn node-of?
   "Returns true if the given element `e` is a node of `kind`."
   [kind e]
@@ -739,41 +732,6 @@
     (assoc e :external true)))
 
 ;;
-;; recursive traversal of the hierarchical data
-;;
-(defn traverse
-  "Recursively traverses the `coll` of elements and returns the elements
-   (selected by the optional `pred-fn`) and transformed by the `step-fn`.
-
-   `pred-fn`     - a predicate on the current element
-   `children-fn` - a function to resolve the children of the current element
-   `step-fn`     - a function with three signatures [], [acc] and [acc e]
-   
-   The no args signature of the `step-fn` should return an empty accumulator,
-   the one args signature extracts the result from the accumulator on return
-   and the 2 args signature receives the accumulator and the current element and
-   should add the transformed element to the accumulator."
-  ([step-fn coll]
-   (traverse identity identity :ct step-fn coll))
-  ([pred-fn step-fn coll]
-   (traverse identity pred-fn :ct step-fn coll))
-  ([pred-fn children-fn step-fn coll]
-   (traverse identity pred-fn children-fn step-fn coll))
-  ([element-fn pred-fn children-fn step-fn coll]
-   (letfn [(trav [acc coll]
-             (if (seq coll)
-               (let [e (element-fn (first coll))]
-                 (if (pred-fn e)
-                   (recur (trav (step-fn acc e) (children-fn e))
-                          (rest coll))
-                   (recur (trav acc (children-fn e))
-                          (rest coll))))
-               (step-fn acc)))]
-     (trav (step-fn) coll))))
-
-; TODO try with tree-seq
-
-;;
 ;; step functions for traverse
 ;;
 (defn tree->set
@@ -812,46 +770,9 @@
 ;   Adds the association of the id of the element `e` to the map `acc`."
 ; (key->element :id))
 
-(defn id->parent
-  "Step function to create an id to parent element map.
-   Adds the association from the id of element `e` to the parent `p` to the map `acc`.
-   Uses a list as stack in the accumulator to manage the context of the current element `e`
-   in the traversal of the tree."
-  ([] [{} '()])
-  ([[res ctx]]
-   (if-not (empty? ctx)
-     [res (pop ctx)]
-     res))
-  ([[res ctx] e]
-   (let [p (peek ctx)]
-     (if (child? e p)
-       [(assoc res (:id e) p) (conj ctx e)]
-       [res (conj ctx e)]))))
-
-(defn referrer-id->relation
-  "Step function to create an map of referrer ids to relations.
-   Adds the relation `r` to the set associated with the id of the :from reference in the map `acc`."
-  ([] {})
-  ([acc] acc)
-  ([acc e]
-   (assoc acc (:from e) (conj (get acc (:from e) #{}) e))))
-
-(defn referred-id->relation
-  "Step function to create an map of referred ids to relations.
-   Adds the relation `r` to the set associated with the id of the :to reference in the map `acc`."
-  ([] {})
-  ([acc] acc)
-  ([acc e]
-   (assoc acc (:to e) (conj (get acc (:to e) #{}) e))))
-
 ;;
 ;; Accessors and transformations
 ;;
-(defn children
-  "Returns the children of the element `e`."
-  [e]
-  (:ct e))
-
 (defn id->element-map
   "Returns am map of id -> element for the given `elements`."
   ([elements]
@@ -886,35 +807,6 @@
   "Returns a vector of the technologies used by the element `e`."
   [e]
   (fns/tokenize-string (get e :tech "")))
-
-(defn collect-technologies
-  "Returns the set of technologies for the elements of the coll."
-  [coll]
-  (traverse :tech tech-collector coll))
-
-(defn collect-fields
-  "Returns the fields of all classes in the `coll`."
-  [coll]
-  (->> coll
-       (filter #(= :class (:el %)))
-       (map :ct)
-       (remove nil?)
-       (map set)
-       (apply set/union)
-       (filter #(= :field (:el %)))
-       (sort-by :name)))
-
-(defn collect-methods
-  "Returns the methods of all classes in the `coll`."
-  [coll]
-  (->> coll
-       (filter #(= :class (:el %)))
-       (map :ct)
-       (remove nil?)
-       (map set)
-       (apply set/union)
-       (filter #(= :method (:el %)))
-       (sort-by :name)))
 
 ;;;
 ;;; Criteria Predicates
@@ -1131,11 +1023,6 @@
   "Returns true if all of the tags in `v` are tags of `e`."
   [v e]
   (set/subset? (set v) (:tags e)))
-
-(defn parent-check?
-  "Returns true if the check for children of `e` equals the boolean value `v`"
-  [v e]
-  (= v (empty? (:ct e))))
 
 (defn key-check?
   "Returns true if the check for the key `k` on element `e` equals the boolean value `v`.

--- a/src/org/soulspace/overarch/domain/element.clj
+++ b/src/org/soulspace/overarch/domain/element.clj
@@ -705,12 +705,15 @@
    The generated id takes the id of `p` as prefix and appends the lowercase
    name of `e` and the element type of `e` separated by a hyphen."
   ([e p]
-   (when (and e p (:id p))
+   (when (and e p (:id p) (:name e))
      (let [p-namespace (namespace (:id p))
            p-name (name (:id p))]
-       (keyword (str p-namespace "/"
-                     p-name "-"
-                     (str/replace (str/lower-case (:name e)) " " "-") "-"
+       (keyword (str p-namespace
+                     "/"
+                     p-name
+                     "-"
+                     (str/replace (str/lower-case (:name e)) " " "-") ; replace spaces with hyphens
+                     "-"
                      (name (:el e))))))))
 
 (defn generate-relation-id

--- a/src/org/soulspace/overarch/domain/model.clj
+++ b/src/org/soulspace/overarch/domain/model.clj
@@ -172,7 +172,7 @@
   [e p]
   (if (:id e)
     e
-    (assoc e (el/generate-node-id e p))))
+    (assoc e :id (el/generate-node-id e p))))
 
 (defn add-node
   "Update the accumulator `acc` of the model with the node `e`

--- a/src/org/soulspace/overarch/domain/model.clj
+++ b/src/org/soulspace/overarch/domain/model.clj
@@ -317,7 +317,7 @@
   (cond
     ;; nodes
     (el/model-node? e)
-    (add-node acc p e)
+    (add-node acc p (identified-node e p))
 
     ;; relations
     (el/model-relation? e)

--- a/src/org/soulspace/overarch/domain/model.clj
+++ b/src/org/soulspace/overarch/domain/model.clj
@@ -65,8 +65,8 @@
   (->> e
        (el/id) 
        (get (:referred-id->relations model))
-       (filter #(= :contained-in (:el %)))
-       ;(map (comp (element-resolver model) :to))
+       (filterv #(= :contained-in (:el %)))
+       (mapv (comp (element-resolver model) :from))
        ))
   
 ;;
@@ -167,10 +167,17 @@
    :name "contained-in"
    :synthetic true})
 
+(defn identified-node
+  "Returns the node `e` with the id set. Generates the id from `e`s name and the parent `p`s id."
+  [e p]
+  (if (:id e)
+    e
+    (assoc e (el/generate-node-id e p))))
+
 (defn add-node
   "Update the accumulator `acc` of the model with the node `e`
    in the context of the parent `p` (if given)."
-  [acc p e]
+  [acc p e] 
   (if (and p (input-child? e p))
     ; TODO add syntetic ids for nodes without ids (e.g. fields, methods)
     ; a child node, add a contained in relationship, too

--- a/src/org/soulspace/overarch/domain/model.clj
+++ b/src/org/soulspace/overarch/domain/model.clj
@@ -161,9 +161,7 @@
   [e p]
   (if (:id e)
     e
-    (let [identified-e (assoc e :id (el/generate-node-id e p))]
-      (println identified-e)
-      identified-e)))
+    (assoc e :id (el/generate-node-id e p))))
 
 (defn contained-in-relation
   "Returns a contained-in relation for parent `p` and element `e`."

--- a/src/org/soulspace/overarch/domain/model.clj
+++ b/src/org/soulspace/overarch/domain/model.clj
@@ -6,13 +6,14 @@
 
    The loaded overarch working model is a map with these keys:
    
-   :input-elements         -> the given data
-   :nodes                  -> the set of nodes (incl. child nodes)
-   :relations              -> the set of relations (incl. contains relations)
+   :input-elements         -> the given data (from edn files)
+   :nodes                  -> the set of all nodes (incl. child nodes)
+   :relations              -> the set of all relations (incl. contained-in relations)
    :views                  -> the set of views
    :themes                 -> the set of themes
    :id->element            -> a map from id to element (nodes, relations and views)
-   :id->parent             -> a map from id to parent element
+   :id->parent             -> a map from id to parent node
+   :id->children           -> a map from id to a vector of contained nodes
    :referrer-id->relations -> a map from id to set of relations where the id is the referrer (:from)
    :referred-id->relations -> a map from id to set of relations where the id is referred (:to)
 "
@@ -57,6 +58,50 @@
   (fn [e]
     (resolve-element model e)))
 
+; TODO resolve children
+(defn children
+  "Returns the children of the model node `e`."
+  [model e]
+  (->> e
+       (el/id) 
+       (get (:referred-id->relations model))
+       (filter #(= :contained-in (:el %)))
+       ;(map (comp (element-resolver model) :to))
+       ))
+  
+;;
+;; recursive traversal of the hierarchical data
+;;
+(defn traverse
+  "Recursively traverses the `coll` of elements and returns the elements
+   (selected by the optional `pred-fn`) and transformed by the `step-fn`.
+
+   `pred-fn`     - a predicate on the current element
+   `children-fn` - a function to resolve the children of the current element
+   `step-fn`     - a function with three signatures [], [acc] and [acc e]
+   
+   The no args signature of the `step-fn` should return an empty accumulator,
+   the one args signature extracts the result from the accumulator on return
+   and the 2 args signature receives the accumulator and the current element and
+   should add the transformed element to the accumulator."
+  ([step-fn coll]
+   (traverse identity identity :ct step-fn coll))
+  ([pred-fn step-fn coll]
+   (traverse identity pred-fn :ct step-fn coll))
+  ([pred-fn children-fn step-fn coll]
+   (traverse identity pred-fn children-fn step-fn coll))
+  ([element-fn pred-fn children-fn step-fn coll]
+   (letfn [(trav [acc coll]
+             (if (seq coll)
+               (let [e (element-fn (first coll))]
+                 (if (pred-fn e)
+                   (recur (trav (step-fn acc e) (children-fn e))
+                          (rest coll))
+                   (recur (trav acc (children-fn e))
+                          (rest coll))))
+               (step-fn acc)))]
+     (trav (step-fn) coll))))
+
 ;;
 ;; recursive traversal of the hierarchical model
 ;;
@@ -92,6 +137,234 @@
                           (rest coll))))
                (step-fn acc)))]
      (trav (step-fn) coll))))
+
+;;;
+;;; Build model
+;;;
+
+(defn prepare-input
+  "Performs transformations on the input `coll` prior to building the model."
+  [coll m])
+
+(defn input-child?
+  "Returns true, if element `e` is a child of model element `p` in the input model."
+  [e p]
+  (boolean (and (seq e)
+                (seq p)
+                (el/identifiable-element? e)
+                (el/identifiable-element? p)
+                (el/model-element? p)
+                ; should be the only place in the code using :ct directly
+                (contains? (set (:ct p)) e))))
+
+(defn contained-in-relation
+  "Returns a contained-in relation for parent `p` and element `e`."
+  [p-id e-id]
+  {:el :contained-in
+   :id (el/generate-relation-id :contained-in e-id p-id)
+   :from e-id
+   :to p-id
+   :name "contained-in"
+   :synthetic true})
+
+(defn add-node
+  "Update the accumulator `acc` of the model with the node `e`
+   in the context of the parent `p` (if given)."
+  [acc p e]
+  (if (and p (input-child? e p))
+    ; TODO add syntetic ids for nodes without ids (e.g. fields, methods)
+    ; a child node, add a contained in relationship, too
+    (let [c-rel (contained-in-relation (:id p) (:id e))]
+      (assoc acc
+             :nodes
+             (conj (:nodes acc) e)
+
+             :relations
+             (conj (:relations acc)
+                   c-rel)
+
+             :id->element
+             (assoc (:id->element acc)
+                    (:id e) e
+                    (:id c-rel) c-rel)
+
+             ; currently only one parent is supported here
+             :id->parent
+             (if-let [po ((:id->parent acc) (:id e))]
+               (println "Error: Illegal override of parent" (:id po) "with" (:id p) "for element id" (:id e))
+               (assoc (:id->parent acc) (:id e) p))
+
+             :id->children
+             (assoc (:id->children acc)
+                    p
+                    (conj (get-in acc [:id->children (:id p)] []) e))
+
+             :referrer-id->relations
+             (assoc (:referrer-id->relations acc)
+                    (:from c-rel)
+                    (conj (get-in acc [:referrer-id->relations (:from c-rel)] #{}) c-rel))
+
+             :referred-id->relations
+             (assoc (:referred-id->relations acc)
+                    (:to c-rel)
+                    (conj (get-in acc [:referred-id->relations (:to c-rel)] #{}) c-rel))))
+
+      ; not a child node, just add the node
+    (assoc acc
+           :nodes
+           (conj (:nodes acc) e)
+
+           :id->element
+           (assoc (:id->element acc) (:id e) e))))
+
+(defn add-reference
+  "Update the accumulator `acc` of the model with the reference `e`
+   in the context of the parent `p` (if given)."
+  [acc p e]
+  (if (el/model-node? p)
+    ; reference is a child of a node, add a contained-in relationship
+    (let [c-rel (contained-in-relation (:id p) (:ref e))]
+      (assoc acc
+             :relations
+             (conj (:relations acc)
+                   c-rel)
+
+             :id->element
+             (assoc (:id->element acc)
+                    (:id e) e
+                    (:id c-rel) c-rel)
+
+             ; currently only one parent is supported here
+             :id->parent
+             (if-let [po ((:id->parent acc) (:ref e))]
+               (println "Error: Illegal override of parent" (:id po) "with" (:id p) "for element id" (:ref e))
+               (assoc (:id->parent acc) (:ref e) p))
+
+             ; FIXME currently adding the ref here, should add the (transformed) element
+             ;       therefore a lookup by id is neccessary for the input elements?!?
+             :id->children
+             (assoc (:id->children acc)
+                    (:id p)
+                    (conj (get-in acc [:id->children (:id p)] []) e))
+
+             :referrer-id->relations
+             (assoc (:referrer-id->relations acc)
+                    (:from c-rel)
+                    (conj (get-in acc [:referrer-id->relations (:from c-rel)] #{}) c-rel))
+
+             :referred-id->relations
+             (assoc (:referred-id->relations acc)
+                    (:to c-rel)
+                    (conj (get-in acc [:referred-id->relations (:to c-rel)] #{}) c-rel))))
+    ; else this reference is a child of a view, leave acc as is
+    acc))
+
+(defn add-relation
+  "Update the accumulator `acc` of the model with the relation `e`
+   in the context of the parent `p` (if given)."
+  [acc p e]
+  (assoc acc
+         :relations
+         (conj (:relations acc) e)
+
+         :id->element
+         (assoc (:id->element acc) (:id e) e)
+
+         :referrer-id->relations
+         (assoc (:referrer-id->relations acc)
+                (:from e)
+                (conj (get-in acc [:referrer-id->relations (:from e)] #{}) e))
+
+         :referred-id->relations
+         (assoc (:referred-id->relations acc)
+                (:to e)
+                (conj (get-in acc [:referred-id->relations (:to e)] #{}) e))))
+
+(defn add-theme
+  "Update the accumulator `acc` of the model with the view `e`
+   in the context of the parent `p` (if given)."
+  [acc p e]
+  (assoc acc
+         :themes
+         (conj (:themes acc) e)
+
+         :id->element
+         (assoc (:id->element acc) (:id e) e)))
+
+(defn add-view
+  "Update the accumulator `acc` of the model with the view `e`
+   in the context of the parent `p` (if given)."
+  [acc p e]
+  ;; views
+  (assoc acc
+         :views
+         (conj (:views acc) e)
+
+         :id->element
+         (assoc (:id->element acc) (:id e) e)))
+
+(defn update-acc
+  "Update the accumulator `acc` of the model with the element `e`
+   in the context of the parent `p` (if given)."
+  [acc p e]
+  (cond
+    ;; nodes
+    (el/model-node? e)
+    (add-node acc p e)
+
+    ;; relations
+    (el/model-relation? e)
+    (add-relation acc p e)
+
+    ;; views
+    (el/view? e)
+    (add-view acc p e)
+
+    ;; references
+    (el/reference? e)
+    (add-reference acc p e)
+
+    ;; themes
+    (el/theme? e)
+    (add-theme acc p e)
+
+    ; unhandled element
+    :else (do (println "Unhandled:" e) acc)))
+
+(defn ->relational-model
+  "Step function for the conversion of the hierachical input model into a relational model of nodes, relations and views."
+  ([]
+   ; initial compound accumulator with empty model and context
+   [{:nodes #{}
+     :relations #{}
+     :views #{}
+     :themes #{}
+     :id->element {}
+     :id->parent {}
+     :id->children {}
+     :referred-id->relations {}
+     :referrer-id->relations {}}
+    '()])
+  ([[res ctx]]
+   ; return result from accumulator
+   (if-not (empty? ctx)
+     ; not done yet because context stack is not empty
+     ; pop element from stack and return accumulator with
+     ; current resulting model and popped context
+     [res (pop ctx)]
+     res))
+  ([[res ctx] e]
+   ; update accumulator in step by calling update function
+   ; with result, parent from context stack (if any) and
+   ; the current element. Also push current element to context stack.
+   (let [p (peek ctx)]
+     [(update-acc res p e) (conj ctx e)])))
+
+(defn build-model
+  "Builds the working model from the input `coll` of elements."
+  [coll]
+  (let [model (traverse ->relational-model coll)]
+    (assoc model :input-elements coll)))
 
 ;;
 ;; Model transducer functions
@@ -170,19 +443,42 @@
   [model]
   (:themes model))
 
-; TODO check
-(defn children
-  "Returns the children of the model node `e`."
-  [model e]
-  (->> e
-       (el/id)
-       (get (:referrer-id->relations model))
-       (filter #(= :contains (:el %)))))
-  
 (defn parent
   "Returns the parent of the model node `e`."
   [model e]
   ((:id->parent model) (:id e)))
+
+#_(defn id->parent
+  "Step function to create an id to parent element map.
+   Adds the association from the id of element `e` to the parent `p` to the map `acc`.
+   Uses a list as stack in the accumulator to manage the context of the current element `e`
+   in the traversal of the tree."
+  ([] [{} '()])
+  ([[res ctx]]
+   (if-not (empty? ctx)
+     [res (pop ctx)]
+     res))
+  ([[res ctx] e]
+   (let [p (peek ctx)]
+     (if (child? e p)
+       [(assoc res (:id e) p) (conj ctx e)]
+       [res (conj ctx e)]))))
+
+#_(defn referrer-id->relation
+  "Step function to create an map of referrer ids to relations.
+   Adds the relation `r` to the set associated with the id of the :from reference in the map `acc`."
+  ([] {})
+  ([acc] acc)
+  ([acc e]
+   (assoc acc (:from e) (conj (get acc (:from e) #{}) e))))
+
+#_(defn referred-id->relation
+  "Step function to create an map of referred ids to relations.
+   Adds the relation `r` to the set associated with the id of the :to reference in the map `acc`."
+  ([] {})
+  ([acc] acc)
+  ([acc e]
+   (assoc acc (:to e) (conj (get acc (:to e) #{}) e))))
 
 (defn from-name
   "Returns the name of the from reference of the relation `rel` in the context of the `model`."
@@ -243,7 +539,7 @@
   ([model e]
    )
   ([model f e]
-   (el/traverse (element-resolver model) identity f ->transitive-related #{e})))
+   (traverse (element-resolver model) identity f ->transitive-related #{e})))
 
 (defn ancestor-nodes
   "Returns the ancestor nodes of the model node `e` in the `model`."
@@ -267,7 +563,7 @@
   "Returns the set of descendants of the node `e`."
   [model e]
   (when (el/model-node? (resolve-element model e))
-    (el/traverse (element-resolver model) el/model-node? :ct el/tree->set (:ct e))))
+    (traverse (element-resolver model) el/model-node? :ct el/tree->set (:ct e))))
 
 (defn descendant-node?
   "Returns true, if `c` is a descendant of `e`."
@@ -511,6 +807,30 @@
   [model e]
   (let []))
 
+(defn collect-fields
+  "Returns the fields of all classes in the `coll`."
+  [model coll]
+  (->> coll
+       (filter #(= :class (:el %)))
+       (map #(children model %))
+       (remove nil?)
+       (map set)
+       (apply set/union)
+       (filter #(= :field (:el %)))
+       (sort-by :name)))
+
+(defn collect-methods
+  "Returns the methods of all classes in the `coll`."
+  [model coll]
+  (->> coll
+       (filter #(= :class (:el %)))
+       (map #(children model %))
+       (remove nil?)
+       (map set)
+       (apply set/union)
+       (filter #(= :method (:el %)))
+       (sort-by :name)))
+
 ;;
 ;; concept model
 ;;
@@ -648,176 +968,6 @@
        (into #{} (referrer-xf model #(= :responsibility (:el %))))))
 
 ;;;
-;;; Build model
-;;;
-(defn parent-of-relation
-  "Returns a parent-of relation for parent `p` and element `e`."
-  [p-id e-id]
-  {:el :contains
-   :id (el/generate-relation-id :contains p-id e-id)
-   :from p-id
-   :to e-id
-   :name "contains"
-   :synthetic true})
-
-(defn update-acc
-  "Update the accumulator `acc` of the model with the element `e`
-   in the context of the parent `p` (if given)."
-  [acc p e]
-  (cond
-    ;; nodes
-    (el/model-node? e)
-    (if (and p (el/child? e p))
-      ; TODO add syntetic ids for nodes without ids (e.g. fields, methods)
-      ; a child node, add a parent-of relationship, too
-      (let [r (parent-of-relation (:id p) (:id e))]
-        (assoc acc
-               :nodes
-               (conj (:nodes acc) e)
-
-               :relations
-               (conj (:relations acc) r)
-
-               :id->element
-               (assoc (:id->element acc)
-                      (:id e) e
-                      (:id r) r)
-
-               ; currently only one parent is supported here
-               :id->parent
-               (if-let [po ((:id->parent acc) (:id e))]
-                 (println "Error: Illegal override of parent" (:id po) "with" (:id p) "for element id" (:id e))
-                 (assoc (:id->parent acc) (:id e) p))
-
-               :referrer-id->relations
-               (assoc (:referrer-id->relations acc)
-                      (:from r)
-                      (conj (get-in acc [:referrer-id->relations (:from r)] #{}) r))
-
-               :referred-id->relations
-               (assoc (:referred-id->relations acc)
-                      (:to r)
-                      (conj (get-in acc [:referred-id->relations (:to r)] #{}) r))))
-
-      ; not a child node, just add the node
-      (assoc acc
-             :nodes
-             (conj (:nodes acc) e)
-
-             :id->element
-             (assoc (:id->element acc) (:id e) e)))
-
-    ;; relations
-    (el/model-relation? e)
-    (assoc acc
-           :relations
-           (conj (:relations acc) e)
-
-           :id->element
-           (assoc (:id->element acc) (:id e) e)
-
-           :referrer-id->relations
-           (assoc (:referrer-id->relations acc)
-                  (:from e)
-                  (conj (get-in acc [:referrer-id->relations (:from e)] #{}) e))
-
-           :referred-id->relations
-           (assoc (:referred-id->relations acc)
-                  (:to e)
-                  (conj (get-in acc [:referred-id->relations (:to e)] #{}) e)))
-
-    ;; views
-    (el/view? e)
-    (assoc acc
-           :views
-           (conj (:views acc) e)
-
-           :id->element
-           (assoc (:id->element acc) (:id e) e))
-
-    ;; references
-    (el/reference? e)
-    (if (el/model-node? p)
-      ; reference is a child of a node, add a parent-of relationship
-      (let [r (parent-of-relation (:id p) (:ref e))]
-        (assoc acc
-               :relations
-               (conj (:relations acc) r)
-
-               :id->element
-               (assoc (:id->element acc) (:id r) r)
-
-               ; currently only one parent is supported here
-               :id->parent
-               (if-let [po ((:id->parent acc) (:id e))]
-                 (println "Error: Illegal override of parent" (:id po) "with" (:id p) "for element ref" (:ref e))
-                 (assoc (:id->parent acc) (:ref e) p))
-
-               :referrer-id->relations
-               (assoc (:referrer-id->relations acc)
-                      (:from r)
-                      (conj (get-in acc [:referrer-id->relations (:from r)] #{}) r))
-
-               :referred-id->relations
-               (assoc (:referred-id->relations acc)
-                      (:to r)
-                      (conj (get-in acc [:referred-id->relations (:to r)] #{}) r))))
-      ; reference is a child of a view, leave as is
-      acc)
-
-    ;; themes
-    (el/theme? e)
-    (assoc acc
-       :themes
-       (conj (:themes acc) e)
-
-       :id->element
-       (assoc (:id->element acc) (:id e) e))
-
-    ; unhandled element
-    :else (do (println "Unhandled:" e) acc)))
-
-(defn ->relational-model
-  "Step function for the conversion of the hierachical input model into a relational model of nodes, relations and views."
-  ([]
-   ; initial compound accumulator with empty model and context
-   [{:nodes #{}
-     :relations #{}
-     :views #{}
-     :themes #{}
-     :id->element {}
-     :id->parent {}
-     :referred-id->relations {}
-     :referrer-id->relations {}}
-    '()])
-  ([[res ctx]]
-   ; return result from accumulator
-   (if-not (empty? ctx)
-     ; not done yet because context stack is not empty
-     ; pop element from stack and return accumulator with
-     ; current resulting model and popped context
-     [res (pop ctx)]
-     res))
-  ([[res ctx] e]
-   ; update accumulator in step by calling update function
-   ; with result, parent from context stack (if any) and
-   ; the current element. Also push current element to context stack.
-   (let [p (peek ctx)]
-     [(update-acc res p e) (conj ctx e)])))
-
-(defn prepare-input
-  "Performs transformations on the input `coll` prior to building the model."
-  [coll m]
-
-  )
-
-(defn build-model
-  "Builds the working model from the input `coll` of elements."
-  [coll]
-  (let [model (el/traverse ->relational-model coll)]
-    (assoc model :input-elements coll)))
-
-;;;
 ;;; filtering element colletions by criteria
 ;;;
 
@@ -834,7 +984,12 @@
 (defn child?
   "Returns true, if `e` is a child of the node with id `v` in the `model`."
   [model v e]
-  (contains? (:ct (resolve-id model v)) e))
+  (contains? (children model (resolve-id model v)) e))
+
+(defn parent-check?
+  "Returns true if the check for children of `e` equals the boolean value `v`"
+  [model v e]
+  (= v (empty? (children model e))))
 
 (defn parent?
   "Returns true if `v` is the parent of `e`"
@@ -934,8 +1089,8 @@
     (= :child? k)                  (partial child-check? model v)
     (= :child-of k)                (partial child? model v)
     (= :descendant-of k)           (partial descendant-of? model v)
-    (= :children? k)               (partial el/parent-check? v) ; deprecate
-    (= :parent? k)                 (partial el/parent-check? v)
+    (= :children? k)               (partial parent-check? model v) ; deprecate
+    (= :parent? k)                 (partial parent-check? model v)
     (= :parent-of k)               (partial parent model v)
     (= :ancestor-of k)             (partial ancestor-of? model v) 
 

--- a/src/org/soulspace/overarch/domain/view.clj
+++ b/src/org/soulspace/overarch/domain/view.clj
@@ -102,8 +102,10 @@
 (defn referenced-elements
   "Returns the `model` elements explicitly referenced in the given `view`."
   [model view]
+  ; use :ct here, not model/children, because the contained-in relations
+  ; are not added for refs in views at the moment
   (->> (:ct view)
-       (map (partial model/resolve-element model))))
+       (map (model/element-resolver model))))
 
 (defn selected-elements
   "Returns the `model` elements selected by criteria for the `view`."

--- a/src/org/soulspace/overarch/domain/view.clj
+++ b/src/org/soulspace/overarch/domain/view.clj
@@ -36,7 +36,7 @@
 (defn include-spec
   "Returns the include specification for the `view`."
   [view]
-  (get-in view [:spec :include]))
+  (get-in view [:spec :include] :referenced-only))
 
 (defn layout-spec
   "Returns the layout specification for the `view`."
@@ -128,7 +128,8 @@
   "Returns the `model` elements specified and included for the view, e.g. related nodes or relations."
   [model view specified]
   (case (include-spec view)
-    :relations (let [nodes (->> specified
+    :relations
+    (let [nodes (->> specified
                                 (filter el/model-node?)
                                 (mapcat (partial model/descendant-nodes model))
                                 (map (partial model/resolve-element model))
@@ -140,10 +141,15 @@
                                    (into #{}))
                      elements (el/union-by-id included specified)]
                  elements)
-    :related (let [included (model/related-nodes model (filter el/model-relation? specified))
+    
+    :related
+    (let [included (model/related-nodes model (filter el/model-relation? specified))
                    elements (el/union-by-id included specified)]
                elements)
-    :referenced-only specified
+    
+    :referenced-only
+    specified
+
     (do
       (println "Unhandled include spec" (include-spec view) "in view" (:id view))
       specified)))

--- a/src/org/soulspace/overarch/domain/views/code_view.clj
+++ b/src/org/soulspace/overarch/domain/views/code_view.clj
@@ -10,11 +10,11 @@
 (defn as-boundary?
   "Returns the boundary element, if the element should be rendered
    as a boundary for this view type, false otherwise."
-  [e]
+  [model e]
   (when (seq e)
     (or (el/boundary? e) ; regular boundary
         (and
-         (seq (:ct e)) ; has children 
+         (seq (model/children model e)) ; has children 
          (element->boundary (:el e)) ; has a boundary mapping for this diagram-type
          (el/internal? e)))))
 

--- a/src/org/soulspace/overarch/domain/views/component_view.clj
+++ b/src/org/soulspace/overarch/domain/views/component_view.clj
@@ -11,11 +11,11 @@
 (defn as-boundary?
   "Returns the boundary element, if the element `e` should be rendered
    as a boundary for this view type, false otherwise."
-  [e]
+  [model e]
   (when (seq e)
     (or (el/boundary? e) ; regular boundary
         (and
-         (seq (:ct e)) ; has children 
+         (seq (model/children model e)) ; has children 
          (element->boundary (:el e)) ; has a boundary mapping for this diagram-type
          (el/internal? e)))))
 
@@ -25,7 +25,7 @@
   (let [p (model/parent model e)]
     (and (contains? el/component-view-element-types (:el e))
          (or (not p) ; has no parent
-             (as-boundary? p) ; parent is rendered as boundary
+             (as-boundary? model p) ; parent is rendered as boundary
              ))))
 
 (defn render-model-relation?
@@ -37,8 +37,8 @@
          (render-model-node? model view from)
          (render-model-node? model view to)
          ; exclude system boundaries
-         (and (not (as-boundary? from))
-              (not (as-boundary? to))))))
+         (and (not (as-boundary? model from))
+              (not (as-boundary? model to))))))
 
 (defmethod view/render-model-element? :component-view
   [model view e]
@@ -53,7 +53,7 @@
 
 (defmethod view/element-to-render :component-view
   [model view e]
-  (if (and (as-boundary? e) (element->boundary (:el e)))
+  (if (and (as-boundary? model e) (element->boundary (:el e)))
     ; e should be rendered as a boundary
     (assoc e :el (element->boundary (:el e)))
     ; render e as normal model element

--- a/src/org/soulspace/overarch/domain/views/concept_view.clj
+++ b/src/org/soulspace/overarch/domain/views/concept_view.clj
@@ -10,11 +10,11 @@
 (defn as-boundary?
   "Returns the boundary element, if the element `e` should be rendered
    as a boundary for this view type, false otherwise."
-  [e]
+  [model e]
   (when (seq e)
     (or (el/boundary? e) ; regular boundary
         (and
-         (seq (:ct e)) ; has children 
+         (seq (model/children model e)) ; has children 
          (element->boundary (:el e)) ; has a boundary mapping for this diagram-type
          (el/internal? e)))))
 

--- a/src/org/soulspace/overarch/domain/views/container_view.clj
+++ b/src/org/soulspace/overarch/domain/views/container_view.clj
@@ -11,11 +11,11 @@
 (defn as-boundary?
   "Returns the boundary element, if the element `e` should be rendered
    as a boundary for this view type, false otherwise."
-  [e]
+  [model e]
   (when (seq e)
    (or (el/boundary? e) ; regular boundary
        (and
-        (seq (:ct e)) ; has children 
+        (seq (model/children model e)) ; has children 
         (element->boundary (:el e)) ; has a boundary mapping for this diagram-type
         (el/internal? e)))))
 
@@ -25,7 +25,7 @@
   (let [p (model/parent model e)]
    (and (contains? el/container-view-element-types (:el e))
         (or (not p) ; has no parent
-            (as-boundary? p) ; parent is rendered as boundary
+            (as-boundary? model p) ; parent is rendered as boundary
             ))))
 
 (defn render-model-relation?
@@ -37,8 +37,8 @@
          (render-model-node? model view from)
          (render-model-node? model view to)
          ; exclude system boundaries
-         (and (not (as-boundary? from))
-              (not (as-boundary? to))))))
+         (and (not (as-boundary? model from))
+              (not (as-boundary? model to))))))
 
 (defmethod view/render-model-element? :container-view
   [model view e]
@@ -49,11 +49,11 @@
 (defmethod view/include-content? :container-view
   [model view e]
   (and (contains? el/container-view-element-types (:el e))
-       (as-boundary? e)))
+       (as-boundary? model e)))
 
 (defmethod view/element-to-render :container-view
   [model view e]
-  (if (and (as-boundary? e) (element->boundary (:el e)))
+  (if (and (as-boundary? model e) (element->boundary (:el e)))
     ; e should be rendered as a boundary
     (assoc e :el (element->boundary (:el e)))
     ; render e as normal model element

--- a/src/org/soulspace/overarch/domain/views/context_view.clj
+++ b/src/org/soulspace/overarch/domain/views/context_view.clj
@@ -10,11 +10,11 @@
 (defn as-boundary?
   "Returns the boundary element, if the element should be rendered
    as a boundary for this view type, false otherwise."
-  [e]
+  [model e]
   (when (seq e)
     (or (el/boundary? e) ; regular boundary
         (and
-         (seq (:ct e)) ; has children 
+         (seq (model/children model e)) ; has children 
          (element->boundary (:el e)) ; has a boundary mapping for this diagram-type
          (el/internal? e)))))
 
@@ -24,7 +24,7 @@
   (let [p (model/parent model e)]
     (and (contains? el/context-view-element-types (:el e))
          (or (not p) ; has no parent
-             (as-boundary? p) ; parent is rendered as boundary
+             (as-boundary? model p) ; parent is rendered as boundary
              ))))
 
 (defn render-model-relation?

--- a/src/org/soulspace/overarch/domain/views/deployment_view.clj
+++ b/src/org/soulspace/overarch/domain/views/deployment_view.clj
@@ -10,11 +10,11 @@
 (defn as-boundary?
   "Returns the boundary element, if the element `e` should be rendered
    as a boundary for this view type, false otherwise."
-  [e]
+  [model e]
   (when (seq e)
     (or (el/boundary? e) ; regular boundary
         (and
-         (seq (:ct e)) ; has children 
+         (seq (model/children model e)) ; has children 
          (element->boundary (:el e)) ; has a boundary mapping for this diagram-type
          (el/internal? e)))))
 

--- a/src/org/soulspace/overarch/domain/views/dynamic_view.clj
+++ b/src/org/soulspace/overarch/domain/views/dynamic_view.clj
@@ -10,11 +10,11 @@
 (defn as-boundary?
   "Returns the boundary element, if the element `e` should be rendered
    as a boundary for this view type, false otherwise."
-  [e]
+  [model e]
   (when (seq e)
     (or (el/boundary? e) ; regular boundary
         (and
-         (seq (:ct e)) ; has children 
+         (seq (model/children model e)) ; has children 
          (element->boundary (:el e)) ; has a boundary mapping for this diagram-type
          (el/internal? e)))))
 

--- a/src/org/soulspace/overarch/domain/views/glossary_view.clj
+++ b/src/org/soulspace/overarch/domain/views/glossary_view.clj
@@ -10,11 +10,11 @@
 (defn as-boundary?
   "Returns the boundary element, if the element `e` should be rendered
    as a boundary for this view type, false otherwise."
-  [e]
+  [model e]
   (when (seq e)
     (or (el/boundary? e) ; regular boundary
         (and
-         (seq (:ct e)) ; has children 
+         (seq (model/children model e)) ; has children 
          (element->boundary (:el e)) ; has a boundary mapping for this diagram-type
          (el/internal? e)))))
 

--- a/src/org/soulspace/overarch/domain/views/state_machine_view.clj
+++ b/src/org/soulspace/overarch/domain/views/state_machine_view.clj
@@ -10,11 +10,11 @@
 (defn as-boundary?
   "Returns the boundary element, if the element `e` should be rendered
    as a boundary for this view type, false otherwise."
-  [e]
+  [model e]
   (when (seq e)
     (or (el/boundary? e) ; regular boundary
         (and
-         (seq (:ct e)) ; has children 
+         (seq (model/children model e)) ; has children 
          (element->boundary (:el e)) ; has a boundary mapping for this diagram-type
          (el/internal? e)))))
 

--- a/src/org/soulspace/overarch/domain/views/system_landscape_view.clj
+++ b/src/org/soulspace/overarch/domain/views/system_landscape_view.clj
@@ -10,11 +10,11 @@
 (defn as-boundary?
   "Returns the boundary element, if the element `e` should be rendered
    as a boundary for this view type, false otherwise."
-  [e]
+  [model e]
   (when (seq e)
     (or (el/boundary? e) ; regular boundary
         (and
-         (seq (:ct e)) ; has children 
+         (seq (model/children model e)) ; has children 
          (element->boundary (:el e)) ; has a boundary mapping for this diagram-type
          (el/internal? e)))))
 
@@ -24,7 +24,7 @@
   (let [p (model/parent model e)]
     (and (contains? el/system-landscape-view-element-types (:el e))
          (or (not p) ; has no parent
-             (as-boundary? p) ; parent is rendered as boundary
+             (as-boundary? model p) ; parent is rendered as boundary
              ))))
 
 (defn render-model-relation?

--- a/src/org/soulspace/overarch/domain/views/use_case_view.clj
+++ b/src/org/soulspace/overarch/domain/views/use_case_view.clj
@@ -10,11 +10,11 @@
 (defn as-boundary?
   "Returns the boundary element, if the element `e` should be rendered
    as a boundary for this view type, false otherwise."
-  [e]
+  [model e]
   (when (seq e)
     (or (el/boundary? e) ; regular boundary
         (and
-         (seq (:ct e)) ; has children 
+         (seq (model/children model e)) ; has children 
          (element->boundary (:el e)) ; has a boundary mapping for this diagram-type
          (el/internal? e)))))
 

--- a/test/org/soulspace/overarch/domain/element_test.clj
+++ b/test/org/soulspace/overarch/domain/element_test.clj
@@ -1174,31 +1174,6 @@
       false {:el :concept-view :id :concept-view}
       false {:el :abcd-view :id :abcd-view})))
 
-(deftest child?-test
-  (testing "child? true"
-    (is (= true (child? {:el :component :id :a/component}
-                        {:el :container
-                         :id :a/container
-                         :ct #{{:el :component
-                                :id :a/component}}}))))
-    (testing "child? false"
-      (are [x y] (= x (child? y
-                              {:el :container
-                               :id :a/container
-                               :ct #{{:el :component
-                                      :id :a/component}}}))
-        false {:el :container
-               :id :a/container
-               :ct #{{:el :component
-                      :id :a/component}}}
-        false nil)))
-
-(comment
-  (child? nil nil)
-  (child? {:el :component :id :a/component} nil)
-  (child? nil {:el :component :id :a/component})
-  )
-
 ;;;
 ;;; Tests for element functions
 ;;;

--- a/test/org/soulspace/overarch/domain/model_test.clj
+++ b/test/org/soulspace/overarch/domain/model_test.clj
@@ -146,10 +146,13 @@
 (deftest referrer-id->relations-test
   (testing "referrer-id->rels"
     (are [x y] (= x y)
-      3 (count (:referrer-id->relations c4-model1))
+      7 (count (:referrer-id->relations c4-model1))
       1 (count (:referrer-id->relations concept-model1))
       2 (count (:test/user1 (:referrer-id->relations c4-model1)))
-      4 (count (:test/system1 (:referrer-id->relations c4-model1))) ; incl. 3 synthetic relations
+      1 (count (:test/system1 (:referrer-id->relations c4-model1))) 
+      4 (count (:test/container1 (:referrer-id->relations c4-model1))) ; 1 synthetic relations
+      1 (count (:test/component11 (:referrer-id->relations c4-model1))) ; 1 synthetic relations
+      1 (count (:test/component12 (:referrer-id->relations c4-model1))) ; 1 synthetic relations
       0 (count (:test/ext-system1 (:referrer-id->relations c4-model1)))
       2 (count (:test/concept1 (:referrer-id->relations concept-model1)))
       0 (count (:test/concept2 (:referrer-id->relations concept-model1)))
@@ -158,10 +161,11 @@
 (deftest referred-id->relations-test
   (testing "referred-id->rels"
     (are [x y] (= x y)
-      7 (count (:referred-id->relations c4-model1))
+      5 (count (:referred-id->relations c4-model1))
       2 (count (:referred-id->relations concept-model1))
       0 (count (:test/user1 (:referred-id->relations c4-model1)))
-      1 (count (:test/system1 (:referred-id->relations c4-model1)))
+      4 (count (:test/system1 (:referred-id->relations c4-model1))) ; 1 synthetic relations
+      3 (count (:test/container1 (:referred-id->relations c4-model1))) ; 1 synthetic relations
       2 (count (:test/ext-system1 (:referred-id->relations c4-model1)))
       0 (count (:test/concept1 (:referred-id->relations concept-model1)))
       1 (count (:test/concept2 (:referred-id->relations concept-model1)))
@@ -226,7 +230,7 @@
        :ct #{{:el :component
               :id :a/component}}}))
   (testing "ancestor-nodes with refs true"
-    (are [x y] (= x (ancestor-nodes hierarchy-model2 y))
+    (are [x y] (= x (do (println hierarchy-model2) (ancestor-nodes hierarchy-model2 y)))
       #{{:el :system
          :id :a/system
          :ct #{{:ref :a/container}}}
@@ -805,6 +809,31 @@
         filter-input)
   ;
   )
+
+(deftest input-child?-test
+  (testing "input-child? true"
+    (is (= true (input-child? {:el :component :id :a/component}
+                        {:el :container
+                         :id :a/container
+                         :ct #{{:el :component
+                                :id :a/component}}}))))
+  (testing "child? false"
+    (are [x y] (= x (input-child? y
+                            {:el :container
+                             :id :a/container
+                             :ct #{{:el :component
+                                    :id :a/component}}}))
+      false {:el :container
+             :id :a/container
+             :ct #{{:el :component
+                    :id :a/component}}}
+      false nil)))
+
+(comment
+  (input-child? nil nil)
+  (input-child? {:el :component :id :a/component} nil)
+  (input-child? nil {:el :component :id :a/component}))
+
 
 ;;
 ;; Class Model

--- a/test/org/soulspace/overarch/domain/views/component_view_test.clj
+++ b/test/org/soulspace/overarch/domain/views/component_view_test.clj
@@ -5,23 +5,41 @@
             [org.soulspace.overarch.domain.model :as model]))
 
 (def test-input
-  #{})
+  #{{:el :enterprise-boundary
+     :id :test/enterprise-boundary1
+     :ct #{{:el :system
+            :id :test/system1
+            :ct #{{:el :context-boundary
+                   :id :test/context-boundary1
+                   :ct #{{:el :container
+                          :id :test/container1
+                          :ct #{{:el :component
+                                 :id :test/component1}}}}}}}}}
+   {:el :system
+    :id :test/system2}})
+
 (def test-model (model/build-model test-input))
 
 (deftest as-boundary?-test
   (testing "as-boundary? true"
-    (are [x y] (= x (boolean (as-boundary? y)))
-      true {:el :enterprise-boundary :ct #{{:el :system}}}
-      true {:el :context-boundary :ct #{{:el :container}}}
-      true {:el :system :ct #{{:el :container}}}
-      true {:el :container :ct #{{:el :component}}}))
+    (are [x y] (= x (boolean (as-boundary? test-model y)))
+      true {:el :enterprise-boundary
+            :id :test/enterprise-boundary1}
+      true {:el :system
+            :id :test/system1}
+      true {:el :context-boundary
+            :id :test/context-boundary1}
+      true {:el :container
+            :id :test/container1}))
   (testing "as-boundary? false"
-    (are [x y] (= x (boolean (as-boundary? y)))
-      false {:el :system}
-      false {:el :container}
-      false {:el :component}
-      false {:el :system :external true :ct #{{:el :container}}}
-      false {:el :container :external true :ct #{{:el :component}}})))
+    (are [x y] (= x (boolean (as-boundary? test-model y)))
+      false {:el :system
+             :id :test/system2}
+      ;false {:el :container}
+      ;false {:el :component}
+      ;false {:el :system :external true :ct #{{:el :container}}}
+      ;false {:el :container :external true :ct #{{:el :component}}}
+      )))
 
 (deftest render-model-element?-test
   (testing "render-model-element? true"

--- a/test/org/soulspace/overarch/domain/views/container_view_test.clj
+++ b/test/org/soulspace/overarch/domain/views/container_view_test.clj
@@ -6,20 +6,33 @@
             [org.soulspace.overarch.domain.model :as model]))
 
 (def test-input
-  #{})
-(def test-model (model/build-model test-input))
+  #{{:el :system
+     :id :test/system1
+     :ct #{{:el :container
+            :id :test/container1
+            :ct #{{:el :component
+                   :id :test/component1}}}}}
+    {:el :system
+     :id :test/system2}})
 
+(def test-model (model/build-model test-input))
 
 (deftest as-boundary?-test
   (testing "as-boundary? true"
-    (are [x y] (= x (boolean (as-boundary? y)))
-      true {:el :system :ct #{{:el :container}}}))
+    (are [x y] (= x (boolean (as-boundary? test-model y)))
+      true {:el :system
+            :id :test/system1
+            :ct #{{:el :container}}}))
   (testing "as-boundary? false"
-    (are [x y] (= x (boolean (as-boundary? y)))
-      false {:el :container :ct #{{:el :component}}}
-      false {:el :system}
-      false {:el :container}
-      false {:el :component})))
+    (are [x y] (= x (boolean (as-boundary? test-model y)))
+      false {:el :container
+             :id :test/container1
+             :ct #{{:el :component}}}
+      false {:el :system
+             :id :test/system2}
+      ;false {:el :container}
+      ;false {:el :component}
+      )))
 
 (deftest render-model-element?-test
   (testing "render-model-element? true"

--- a/test/org/soulspace/overarch/domain/views/state_machine_view_test.clj
+++ b/test/org/soulspace/overarch/domain/views/state_machine_view_test.clj
@@ -14,7 +14,7 @@
     ;(are [x y] (= x (boolean (as-boundary? y))))
     )
   (testing "as-boundary? false"
-    (are [x y] (= x (boolean (as-boundary? y)))
+    (are [x y] (= x (boolean (as-boundary? test-model y)))
       false {:el :state-machine}
       false {:el :start-state}
       false {:el :state}


### PR DESCRIPTION
Changed the handling of contained element hierarchies. 
* synthetic ids are generated for children missing an id (e.g. fields or methods in classes)
* syntethic :contained-by relations are created to represent hierarches graph.
* the children function is used to navigate down the hierarchy in the model graph instead of the :ct key.
